### PR TITLE
Add/fix documentation for align_text_and_volpiano

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ Text and volpiano are first aligned section by section and then word by word in 
 - *Section has more text words than volpiano words*: display "extra" words at end of section and add blank staff space ("-") in volpiano for spacing
 
 The alignment algorithm also adapts the size of missing music sections in the volpiano to the amount of text associated with the missing music. Sections of missing music are always encoded "6------6" in volpiano, regardless of how long the missing section is. For the purposes of browser display, the module may add additional space (ie. add hyphens between the "6"s) to this section to account for text. 
+
+The `align_text_and_volpiano` function accepts a chant's text and volpiano-encoded melody as strings and returns the aligned text and melody. The function returns a list of 2-tuples of strings of the form `(text_string, volpiano_string)`.
+
+```python
+>>> from text_volpiano_alignment import align_text_and_volpiano
+>>> align_text_and_volpiano("Agnus dei qui {tollis peccata} mundi", "1---g--g---gh--h---h---6------6---g--h---3")
+'[("", "1---"), ("A-", "g--"), ("gnus", "g---"), ("de-", "gh--"), ("i", "h---"), ("qui", "h---"), ("{tollis peccata}", "6----------------6---"), ("mun-", "g--"), ("di", "h---"), ("", "3")]'
+```
+
 ### Word Syllabification
 
 `syllabify_word` syllabifies individual latin words according to linguistic rules. `syllabify_word` can either return a list of syllable boundaries or a string hyphenated at syllable boundaries. Strings passed to `syllabify_word` must contain only ASCII alphabetic characters; strings with other characters will raise a `ValueError`. 

--- a/text_volpiano_alignment.py
+++ b/text_volpiano_alignment.py
@@ -167,14 +167,14 @@ def _align_section(
 
 
 def align_text_and_volpiano(
-    chant_text: str, volpiano_str: str
+    chant_text: str, volpiano: str
 ) -> "list[tuple[str, str]]":
     """
     Aligns syllabified text with volpiano, performing periodic sanity checks
     and accounting for misalignments.
 
-    chant_text str: chant text string
-    volpiano_str [str]: volpiano string
+    chant_text [str]: the text of a chant
+    volpiano [str]: the volpiano for a chant
 
     returns [list[tuple[str, str]]]: list of tuples of text syllables and volpiano syllables
         as (text_str, volpiano_str)
@@ -183,11 +183,11 @@ def align_text_and_volpiano(
         chant_text, clean_text=False, flatten_result=False
     )
     # Performs some validation on the passed volpiano string
-    volpiano_str = _preprocess_volpiano(volpiano_str)
+    volpiano = _preprocess_volpiano(volpiano)
     # Section volpiano to match text sections returned by syllabify_text
     # Split at clefs, barlines, and missing music markers, removing empty
     # sections created by the split.
-    volpiano_sections = re.split(r"([134]-*|6-{6}6-{3})", volpiano_str)
+    volpiano_sections = re.split(r"([134]-*|6-{6}6-{3})", volpiano)
     volpiano_sections = list(filter(lambda x: x != "", volpiano_sections))
     logging.debug("Volpiano sections: %s", volpiano_sections)
     if len(volpiano_sections) == len(syllabified_text) + 2:

--- a/text_volpiano_alignment.py
+++ b/text_volpiano_alignment.py
@@ -167,16 +167,17 @@ def _align_section(
 
 
 def align_text_and_volpiano(
-    chant_text: "list[list[list[str]]]", volpiano_str: str
+    chant_text: str, volpiano_str: str
 ) -> "list[tuple[str, str]]":
     """
     Aligns syllabified text with volpiano, performing periodic sanity checks
     and accounting for misalignments.
 
-    chant_text list[list[list[str]]]]: syllabified text
+    chant_text str: chant text string
     volpiano_str [str]: volpiano string
 
     returns [list[tuple[str, str]]]: list of tuples of text syllables and volpiano syllables
+        as (text_str, volpiano_str)
     """
     syllabified_text = syllabify_text(
         chant_text, clean_text=False, flatten_result=False


### PR DESCRIPTION
Adds some documentation for the `align_text_and_volpiano` function to the README. 

Fixes erroneous documentation of the same function in the function docstring.