### PR TITLE
Add support for presyllabified text to text syllabification and alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The function returns a nested list of strings with the following structure (see 
  - each section list is a list of words (for sections where syllabification is necessary) or a list with one element for the whole section (for sections where syllabification is not necessary)
  - each word is a list of syllable strings (if the word needs to be syllabified)
 
-```{mermaid}
+```mermaid
 flowchart TD
     X["Agnus dei qui {tollis peccata} mundi | Miserere # | ~Agnus"] ---> A(("Section text"))
     A ---> B["Agnus dei qui"]

--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ Argument `flatten_result` modifies the function return value.
 'Ag-nus de-i qui {tollis peccata} mun-di | Mi-se-re-re # | ~Agnus'
 ```
 
+Cantus Database allows users to edit the syllabification of a chant text created by the automatic syllabification tool in cases where the automatic syllabification is incorrect, where some misalignment between text and melody exists in the manuscript (eg. a word with two syllables has only one pitch in the manuscript), or any other case where a syllabification of the text different than the default syllabification is preferred. These are stored as strings with syllable boundaries marked by hyphens ("-"). Argument `text_presyllabified` (default = False) allows presyllabified texts to be passed in preparation for alignment with a melody. 
+
+```python
+>>> syllabify_text("Ky-ri-e e-le-i-son | Chri-ste e-lei-son", text_presyllabified = True)
+'[[["Ky-","ri-","e"], ["e-","le-","i-","son"]], [["|"]], [["Chri-","ste"], ["e-","lei-","son"]]]'
+```
+
 Aligning chant texts with melodies requires most words in the chant to be syllabified; however, there are a number of cases in which subsets of chant texts are not syllabified: 
  1. Chant text is missing. Missing chant text is encoded with "#" and is aligned with volpiano but not syllabified.
  2. Music is missing. Text associated with missing music is enclosed within curly braces ("{" and "}"). It is aligned with a section of blank staff but is not syllabified.

--- a/cantus_text_syllabification.py
+++ b/cantus_text_syllabification.py
@@ -115,7 +115,7 @@ def syllabify_text(
         where a CantusDB user has edited the syllabification of a chant text that
         then needs to be aligned with a melody. Already syllabified chant texts
         stored in CantusDB are strings with syllable breaks indicated by hyphens ("-").
-        This function find a syllable split if and only if a hyphen is
+        This function finds a syllable split if and only if a hyphen is
         present (ie. no additional syllabification is performed).
 
     returns [list[list[list[str]]] or str]: by default, a nested list of strings.

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -198,7 +198,7 @@ class TestCantusTextSyllabification(unittest.TestCase):
         # Test presyllabified text
         presyllabified_text = (
             # Test case where a syllable break has been added
-            # to where it might "normalle" occur.
+            # to where it might "normally" occur.
             "Ma-g-ni-fi-cat a-ni-ma me-a do-mi-nu-m | et "
             # Test missing music case
             "ex-ul-ta-vit {spi-ri-tus meus} in de-o | "

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -195,6 +195,48 @@ class TestCantusTextSyllabification(unittest.TestCase):
                     syllabify_text(test_case["test_string"]),
                     test_case["expected_result"],
                 )
+        # Test presyllabified text
+        presyllabified_text = (
+            # Test case where a syllable break has been added
+            # to where it might "normalle" occur.
+            "Ma-g-ni-fi-cat a-ni-ma me-a do-mi-nu-m | et "
+            # Test missing music case
+            "ex-ul-ta-vit {spi-ri-tus meus} in de-o | "
+            # Test incipit case
+            "{sa-lu-ta-ri} me-o | ~Quia [re-spex-it] | "
+            # Test missing words and missing words + music case
+            "# hu-mi-li- # # -lae su- {#} "
+            # Test case where we might expect a syllable break, but
+            # user has removed syllable break.
+            "| ecce enim ex hoc be-a-tam"
+        )
+        expected_result = [
+            [
+                ["Ma-", "g-", "ni-", "fi-", "cat"],
+                ["a-", "ni-", "ma"],
+                ["me-", "a"],
+                ["do-", "mi-", "nu-", "m"],
+            ],
+            [["|"]],
+            [["et"], ["ex-", "ul-", "ta-", "vit"]],
+            [["{spi-ri-tus meus}"]],
+            [["in"], ["de-", "o"]],
+            [["|"]],
+            [["{sa-lu-ta-ri}"]],
+            [["me-", "o"]],
+            [["|"]],
+            [["~Quia [re-spex-it]"]],
+            [["|"]],
+            [["#"], ["hu-", "mi-", "li-"], ["#"], ["#"], ["-lae"], ["su-"]],
+            [["{#}"]],
+            [["|"]],
+            [["ecce"], ["enim"], ["ex"], ["hoc"], ["be-", "a-", "tam"]],
+        ]
+        with self.subTest("Presyllabified Text"):
+            self.assertEqual(
+                syllabify_text(presyllabified_text, text_presyllabified=True),
+                expected_result,
+            )
 
 
 class TestTextVolpianoAlignment(unittest.TestCase):

--- a/text_volpiano_alignment.py
+++ b/text_volpiano_alignment.py
@@ -167,7 +167,8 @@ def _align_section(
 
 
 def align_text_and_volpiano(
-    chant_text: "list[list[list[str]]]", volpiano_str: str
+    chant_text: "list[list[list[str]]]", volpiano_str: str,
+    text_presyllabified: bool = False,
 ) -> "list[tuple[str, str]]":
     """
     Aligns syllabified text with volpiano, performing periodic sanity checks
@@ -175,11 +176,14 @@ def align_text_and_volpiano(
 
     chant_text list[list[list[str]]]]: syllabified text
     volpiano_str [str]: volpiano string
+    text_presyllabified [bool]: whether the text is already syllabified. Passed
+        to syllabify_text (see that functions documentation for more details). Defaults 
+        to False.
 
     returns [list[tuple[str, str]]]: list of tuples of text syllables and volpiano syllables
     """
     syllabified_text = syllabify_text(
-        chant_text, clean_text=False, flatten_result=False
+        chant_text, clean_text=False, flatten_result=False, text_presyllabified=text_presyllabified
     )
     # Performs some validation on the passed volpiano string
     volpiano_str = _preprocess_volpiano(volpiano_str)


### PR DESCRIPTION
Closes #6. Provides support for presyllabified texts. Cantus DB users can edit a chant text syllabification, which is then stored in Cantus DB as a string with hyphens marking syllable breaks. These stored strings can be passed to `align_text_and_volpiano` and `syllabify_text` functions along with setting the `text_presyllabified` of those argument to `True`.

Also fixes a typo in the README that was preventing a mermaid diagram from rendering.