### PR TITLE
Add option to clean_text during text-volpiano alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,11 @@ The `align_text_and_volpiano` function accepts a chant's text and volpiano-encod
 '[("", "1---"), ("A-", "g--"), ("gnus", "g---"), ("de-", "gh--"), ("i", "h---"), ("qui", "h---"), ("{tollis peccata}", "6----------------6---"), ("mun-", "g--"), ("di", "h---"), ("", "3")]'
 ```
 
+The `align_text_and_volpiano` function also takes the following optional arguments:
+  - `text_presyllabified`: A boolean indicating whether the text passed to the function has already been syllabified (with hyphens marking syllable boundaries). Defaults to `False`.
+  - `clean_text`: A boolean passed to the text syllabification tool indicating whether text should be stripped of invalid characters before syllabification. Defaults to `False`.
+
+
 ### Word Syllabification
 
 `syllabify_word` syllabifies individual latin words according to linguistic rules. `syllabify_word` can either return a list of syllable boundaries or a string hyphenated at syllable boundaries. Strings passed to `syllabify_word` must contain only ASCII alphabetic characters; strings with other characters will raise a `ValueError`. 

--- a/volpiano_display_utilities/text_volpiano_alignment.py
+++ b/volpiano_display_utilities/text_volpiano_alignment.py
@@ -178,6 +178,7 @@ def align_text_and_volpiano(
     chant_text: str,
     volpiano: str,
     text_presyllabified: bool = False,
+    clean_text: bool = False,
 ) -> List[Tuple[str, str]]:
     """
     Aligns syllabified text with volpiano, performing periodic sanity checks
@@ -188,13 +189,16 @@ def align_text_and_volpiano(
     text_presyllabified [bool]: whether the text is already syllabified. Passed
         to syllabify_text (see that functions documentation for more details). Defaults
         to False.
+    clean_text [bool]: whether to clean the text before syllabifying. Passed to
+        syllabify_text (see that functions documentation for more details). Defaults
+        to False.
 
     returns [list[tuple[str, str]]]: list of tuples of text syllables and volpiano syllables
         as (text_str, volpiano_str)
     """
     syllabified_text = syllabify_text(
         chant_text,
-        clean_text=False,
+        clean_text=clean_text,
         flatten_result=False,
         text_presyllabified=text_presyllabified,
     )


### PR DESCRIPTION
Closes #20 

This also closes #17. Asterisks will be removed when `clean_text` is `True` and will no longer be an issue in the alignment process. 