### PR TITLE
Handle case of overlapping consonant clusters

### DIFF
--- a/tests/word_syllabification_tests.csv
+++ b/tests/word_syllabification_tests.csv
@@ -84,4 +84,7 @@ iacula,ia-cu-la,
 iubilemus,iu-bi-le-mus,
 iubet,iu-bet,
 in,in,
-maior,ma-ior
+maior,ma-ior,
+amplius,am-pli-us,
+adincresco,ad-in-cre-sco,
+compressans,com-pres-sans

--- a/volpiano_display_utilities/latin_word_syllabification.py
+++ b/volpiano_display_utilities/latin_word_syllabification.py
@@ -241,7 +241,9 @@ def _get_syl_bound_position(ltrs_btw_vow_grps: str) -> Tuple[int, str]:
         else:
             split_case = "2 consonants between vowels (consonant group)"
     else:
-        if ltrs_btw_vow_grps[:2] in _CONSONANT_GROUPS:
+        if ltrs_btw_vow_grps[1:] in _CONSONANT_GROUPS:
+            syl_bound = num_ltrs_btw_vow_grps - 2
+        elif ltrs_btw_vow_grps[:2] in _CONSONANT_GROUPS:
             syl_bound = 2
         else:
             syl_bound = 1

--- a/volpiano_display_utilities/latin_word_syllabification.py
+++ b/volpiano_display_utilities/latin_word_syllabification.py
@@ -241,6 +241,11 @@ def _get_syl_bound_position(ltrs_btw_vow_grps: str) -> Tuple[int, str]:
         else:
             split_case = "2 consonants between vowels (consonant group)"
     else:
+        # in situations where 3 or more consonants are between consecutive vowels,
+        # group the final two consonants, if possible (amplius -> am-pl-ius). If not,
+        # group the first two consonants (coniunctos -> con-iunc-tos), if possible. If
+        # neither the final two nor first two consonants can be grouped, split after
+        # the first consonant.
         if ltrs_btw_vow_grps[1:] in _CONSONANT_GROUPS:
             syl_bound = num_ltrs_btw_vow_grps - 2
         elif ltrs_btw_vow_grps[:2] in _CONSONANT_GROUPS:


### PR DESCRIPTION
Fixes #33.

In latin syllabification, where vowels are separated by 3 or more consonants and those consonants form multiple (potentially overlapping) consonant clusters, we prioritize a consonant cluster in the final two letters over a consonant cluster in the first two letters. 

Adds relevant test words.