### PR TITLE
Return boolean from alignment process indicating need for manual correction of encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Text and volpiano are first aligned section by section and then word by word in 
 
 The alignment algorithm also adapts the size of missing music sections in the volpiano to the amount of text associated with the missing music. Sections of missing music are always encoded "6------6" in volpiano, regardless of how long the missing section is. For the purposes of browser display, the module may add additional space (ie. add hyphens between the "6"s) to this section to account for text. 
 
-The `align_text_and_volpiano` function accepts a chant's text and volpiano-encoded melody as strings and returns the aligned text and melody. The function returns a list of 2-tuples of strings of the form `(text_string, volpiano_string)`.
+The `align_text_and_volpiano` function accepts a chant's text and volpiano-encoded melody as strings and returns the aligned text and melody. The function returns a list of 2-tuples of strings of the form `(text_string, volpiano_string)` and a boolean that flags whether or not the alignment process encountered any errors in the encodings. This boolean is meant to identify cases where manual correction might be called for while still returning a passable alignment for immediate use.
 
 ```python
 >>> from text_volpiano_alignment import align_text_and_volpiano
@@ -97,7 +97,6 @@ The `align_text_and_volpiano` function accepts a chant's text and volpiano-encod
 
 The `align_text_and_volpiano` function also takes the following optional arguments:
   - `text_presyllabified`: A boolean indicating whether the text passed to the function has already been syllabified (with hyphens marking syllable boundaries). Defaults to `False`.
-  - `clean_text`: A boolean passed to the text syllabification tool indicating whether text should be stripped of invalid characters before syllabification. Defaults to `False`.
 
 
 ### Word Syllabification

--- a/tests/alignment_test_cases.json
+++ b/tests/alignment_test_cases.json
@@ -3,6 +3,27 @@
         "case_name": "Test alignment: no special characters",
         "text_input": "in diebus eius obsessa est",
         "vol_input": "1---f---df--f--f---f--efgfe---g--hg-hgf--ef-gef---ed---4",
+        "review_encoding_flag": false,
+        "expected_result": [
+            [ "", "1---" ],
+            [ "in", "f---" ],
+            [ "di-", "df--" ],
+            [ "e-", "f--" ],
+            [ "bus", "f---" ],
+            [ "e-", "f--" ],
+            [ "ius", "efgfe---" ],
+            [ "ob-", "g--" ],
+            [ "ses-", "hg-hgf--" ],
+            [ "sa", "ef-gef---" ],
+            [ "est", "ed---" ],
+            [ "", "4" ]
+        ]
+    },
+    {
+        "case_name": "Test alignment: improper text characters",
+        "text_input": "in diebus eius @%) obsessa est",
+        "vol_input": "1---f---df--f--f---f--efgfe---g--hg-hgf--ef-gef---ed---4",
+        "review_encoding_flag": true, 
         "expected_result": [
             [ "", "1---" ],
             [ "in", "f---" ],
@@ -22,6 +43,7 @@
         "case_name": "Test alignment: no special characters, long syllables",
         "text_input": "in spargere fractum",
         "vol_input": "1---f---f--f--f---f--f---4",
+        "review_encoding_flag": false,
         "expected_result": [
             [ "", "1---" ],
             [ "in", "f---" ],
@@ -37,6 +59,8 @@
         "case_name": "Test alignment: internal bar lines",
         "text_input": "in diebus |eius | obsessa est",
         "vol_input": "1---f---df--f--f---3---f--efgfe---4g--hg-hgf--ef-gef---ed---3",
+        "review_encoding_flag": true,
+        "_comment": "Improper spacing after second volpiano barline",
         "expected_result": [
             [ "", "1---" ],
             [ "in", "f---" ],
@@ -58,6 +82,7 @@
         "case_name": "Test alignment: missing final barline",
         "text_input": "in diebus",
         "vol_input": "1---f---df--f--f--",
+        "review_encoding_flag": true,
         "expected_result": [
             [ "", "1---" ],
             [ "in", "f---" ],
@@ -71,6 +96,7 @@
         "case_name": "Test alignment: improper spacing with final barline",
         "text_input": "in diebus",
         "vol_input": "1---f---df--f--f--3",
+        "review_encoding_flag": true,
         "expected_result": [
             [ "", "1---" ],
             [ "in", "f---" ],
@@ -84,6 +110,7 @@
         "case_name": "Test alignment: missing music",
         "text_input": "in {diebus add char} e- {ius} obsessa est",
         "vol_input": "1---f---6------6---f---6------6---g--hg-hgf--ef-gef---ed---3",
+        "review_encoding_flag": false,
         "expected_result": [
             [ "", "1---" ],
             [ "in", "f---" ],
@@ -101,6 +128,8 @@
         "case_name": "Test alignment: missing music followed by line breaks (CDB Chant 229133)",
         "text_input": "{Domini est terra et} plenitudo e {ius orbis terrarum et uni} versi qui habitant {in eo}",
         "vol_input": "1---6------67---ghg--h--hkhg--hf-gh-kjh-jkjh---ghkhgh---6------67---kjhg--hghg-gF--gf---fd---efe--f--fh---6------67---4",
+        "review_encoding_flag": true,
+        "_comment": "Volpiano requires padding at word 'versi'",
         "expected_result": [
             ["", "1---"],
             ["{Domini est terra et}", "6---------------------67---"],
@@ -125,6 +154,7 @@
         "case_name": "Test alignment: Missing music encoded with too few internal hyphens",
         "text_input": "in {diebus} e- {ius} obsessa est",
         "vol_input": "1---f---6--6---f---6----6---g--hg-hgf--ef-gef---ed---3",
+        "review_encoding_flag": true,
         "expected_result": [
             ["", "1---"],
             ["in", "f---"],
@@ -142,6 +172,7 @@
         "case_name": "Test alignment: Missing music encoded with too many internal hyphens",
         "text_input": "in {diebus} e- {ius} obsessa est",
         "vol_input": "1---f---6-------6---f---6-----------6---g--hg-hgf--ef-gef---ed---3",
+        "review_encoding_flag": true,
         "expected_result": [
             ["", "1---"],
             ["in", "f---"],
@@ -159,6 +190,7 @@
         "case_name": "Test alignment: missing words",
         "text_input": "in # eius obsess- #",
         "vol_input": "1---f---df--f--f---f--efgfe---g--hg-hgf---ef--gef--ed---3",
+        "review_encoding_flag": false,
         "expected_result": [
             [ "", "1---" ],
             [ "in", "f---" ],
@@ -179,6 +211,7 @@
         "case_name": "Test alignment: missing words and music",
         "text_input": "in {#} eius obsess- {#}",
         "vol_input": "1---f---6------6---f--efgfe---g--hg-hgf---6------6---3",
+        "review_encoding_flag": false,
         "expected_result": [
             [ "", "1---" ],
             [ "in", "f---" ],
@@ -195,6 +228,7 @@
         "case_name": "Test alignment: overflow text",
         "text_input": "in diebus eius obsessa est",
         "vol_input": "1---f---df--f-f---f---g--hg--hg---4",
+        "review_encoding_flag": true,
         "expected_result": [
             [ "", "1---" ],
             [ "in", "f---" ],
@@ -214,6 +248,7 @@
         "case_name": "Test alignment: overflow volpiano",
         "text_input": "in diebus eius obsessa est",
         "vol_input": "1---f---df--f--f--f---f--efgfe---g--hg-hgf--ef-gef--hj-hj---ed---gh---4",
+        "review_encoding_flag": true,
         "expected_result": [
             [ "", "1---" ],
             [ "in", "f---" ],
@@ -236,6 +271,7 @@
         "case_name": "Test alignment: text with incipit",
         "text_input": "in diebus | ~eius | obsessa | ~est",
         "vol_input": "1---f---df--f--f---3---f--efgfe---3---g--hg-hgf--ef-gef---4---ed---4",
+        "review_encoding_flag": false,
         "expected_result": [
             [ "", "1---" ],
             [ "in", "f---" ],
@@ -257,6 +293,7 @@
         "case_name": "Test alignment: text with ipsum",
         "text_input": "in diebus eius | ~Ipsum [obsessa est]",
         "vol_input": "1---f---df--f--f---f--efgfe---4---g--hg--hgf--ef--gef--ed---4",
+        "review_encoding_flag": false,
         "expected_result": [
             [ "", "1---" ],
             [ "in", "f---" ],
@@ -274,6 +311,8 @@
         "case_name": "Expected version for dropped words in middle of section",
         "text_input": "in diebus eius | obsessa est",
         "vol_input": "1---f---df--f--f---f--efgfe---4g--hg-hgf--ef-gef---ed---3",
+        "review_encoding_flag": true,
+        "_comment": "Improper spacing after first volpiano barline",
         "expected_result": [
             [ "", "1---" ],
             [ "in", "f---" ],
@@ -294,6 +333,7 @@
         "case_name": "Test alignment: dropped text word in middle of section",
         "text_input": "in eius | obsessa est",
         "vol_input": "1---f---df--f--f---f--efgfe---4g--hg-hgf--ef-gef---ed---3",
+        "review_encoding_flag": true,
         "expected_result": [
             [ "", "1---" ],
             [ "in", "f---" ],
@@ -314,6 +354,7 @@
         "case_name": "Test alignment: dropped volpiano word in middle of section",
         "text_input": "in diebus eius | obsessa est",
         "vol_input": "1---f---f--efgfe---4g--hg-hgf--ef-gef---ed---3",
+        "review_encoding_flag": true,
         "expected_result": [
             [ "", "1---" ],
             [ "in", "f---" ],
@@ -334,6 +375,7 @@
         "case_name": "Test alignment: improper clef, preceding characters ",
         "text_input": "in diebus eius obsessa est",
         "vol_input": "-j---1---f---df--f--f---f--efgfe---g--hg-hgf--ef-gef---ed---4",
+        "review_encoding_flag": true,
         "expected_result": [
             ["", "1---"],
             ["in", "f---"],
@@ -353,6 +395,7 @@
         "case_name": "Test alignment: improper clef, improper spacing",
         "text_input": "in diebus eius obsessa est",
         "vol_input": "1--f---df--f--f---f--efgfe---g--hg-hgf--ef-gef---ed---4",
+        "review_encoding_flag": true,
         "expected_result": [
             ["", "1---"],
             ["in", "f---"],
@@ -372,6 +415,7 @@
         "case_name": "Test alignment: improper clef, extra clef",
         "text_input": "in diebus eius obsessa est",
         "vol_input": "1--f---df--f--f---f--efgfe---g--1---hg-hgf--ef-gef---ed---4",
+        "review_encoding_flag": true,
         "expected_result": [
             ["", "1---"],
             ["in", "f---"],
@@ -393,6 +437,8 @@
         "case_name": "Test alignment: line breaks",
         "text_input": "Gabriel | angelus apparuit | Zachariae dicens",
         "vol_input": "1---c--cg7--g---47---g--gf-fef--fe---e--gh--kh-jkjhgh--hg---4--7-c--ded-ef--e--eged-efed---cdedcd--dc---3",
+        "review_encoding_flag": true,
+        "_comment": "Line break should immediately follow barline at second volpiano barline",
         "expected_result": [
             ["", "1---"],
             ["Ga-","c--"],
@@ -420,6 +466,8 @@
         "case_name": "Test alignment: page breaks",
         "text_input": "Gabriel | angelus apparuit | Zachariae dicens",
         "vol_input": "1---c--cg77--g---477---g--gf-fef--fe---e--gh--kh-jkjhgh--hg---4--77-c--ded-ef--e--eged-efed---cdedcd--dc---3",
+        "review_encoding_flag": true,
+        "_comment": "Page break should immediately follow barline at second volpiano barline",
         "expected_result": [
             ["", "1---"],
             ["Ga-","c--"],
@@ -447,6 +495,8 @@
         "case_name": "Test alignment: column breaks",
         "text_input": "Gabriel | angelus apparuit | Zachariae dicens",
         "vol_input": "1---c--cg777--g---4777---g--gf-fef--fe---e--gh--kh-jkjhgh--hg---4--777-c--ded-ef--e--eged-efed---cdedcd--dc---3",
+        "review_encoding_flag": true,
+        "_comment": "Column break should immediately follow barline at second volpiano barline",
         "expected_result": [
             ["", "1---"],
             ["Ga-","c--"],
@@ -474,7 +524,8 @@
         "case_name": "Test alignment: Volpiano missing section barlines",
         "text_input": "in diebus | eius | obsessa est",
         "vol_input": "1---f---df--f--f---f--efgfe---g--hg-hgf--ef-gef---ed---3",
-        "expected_result": [
+        "review_encoding_flag": true,
+        "expected_result":  [
             ["","1---"],
             ["in","f---"],
             ["di-","df--"],
@@ -495,6 +546,7 @@
         "case_name": "Test alignment: Text missing section barlines",
         "text_input": "in diebus eius obsessa est",
         "vol_input": "1---f---df--f--f---4---f--efgfe---4---g--hg-hgf--ef-gef---ed---3",
+        "review_encoding_flag": true,
         "expected_result": [
             ["","1---"],
             ["in","f---"],
@@ -516,6 +568,7 @@
         "case_name": "Test alignment: Volpiano missing section barlines with syllable mismatch",
         "text_input": "in diebus | eius | obsessa est",
         "vol_input": "1---f--df--f--f---f-efgfe---g--hg-hgf--efgef---ed---3",
+        "review_encoding_flag": true,
         "expected_result": [
             ["","1---"],
             ["in","f--"],
@@ -541,6 +594,7 @@
         "case_name": "Test alignment: Text missing section barlines with syllable mismatch",
         "text_input": "in diebus eius obsessa est",
         "vol_input": "1---f--df--f--f--4---f-efgfe---4---g--hg-hgf--ef-gef---ed---3",
+        "review_encoding_flag": true,
         "expected_result": [
             ["","1---"],
             ["in","f--"],
@@ -566,6 +620,7 @@
         "case_name": "Test alignment: Too many hyphens after words",
         "text_input": "Ave Maria gratia plena dominus tecum",
         "vol_input": "1---fgj--jhj-hg---j--gf-ede--f----kh--j--gj---fg--g---fh--jh-gh--g------fef--gf-gf---3",
+        "review_encoding_flag": true,
         "expected_result": [
             ["","1---"],
             ["A-","fgj--"],
@@ -589,14 +644,15 @@
     {
         "case_name": "Text alignment: Consecutive missing music sections",
         "text_input": "Ave Maria {gratia} {plena dominus} tecum",
-        "vol_input": "1---fgj--jhj-hg---j--gf-ede--f----6------67---6------6---fef--gf-gf---3",
+        "vol_input": "1---fgj--jhj-hg---j--gf-ede--f---6------67---6------6---fef--gf-gf---3",
+        "review_encoding_flag": false,
         "expected_result": [
             ["","1---"],
             ["A-","fgj--"],
             ["ve","jhj-hg---"],
             ["Ma-","j--"],
             ["ri-","gf-ede--"],
-            ["a","f----"],
+            ["a","f---"],
             ["{gratia}","6------67---"],
             ["{plena dominus}","6---------------6---"],
             ["te-","fef--"],

--- a/tests/alignment_test_cases.json
+++ b/tests/alignment_test_cases.json
@@ -664,6 +664,7 @@
         "case_name": "Adjust spacing for unsyllabified text sections (no music)",
         "text_input": "Adiuvabit eam deus | ~Deus noster refugium",
         "vol_input": "1---lK--j--l--m---l--l---l--j---4",
+        "review_encoding_flag": true,
         "expected_result": [
             ["","1---"],
             ["Ad-","lK--"],
@@ -683,6 +684,7 @@
         "case_name": "Adjust spacing for unsyllabified text sections (short music)",
         "text_input": "Adiuvabit eam deus | ~Deus noster refugium",
         "vol_input": "1---lK--j--l--m---l--l---l--j---3---g--f---4",
+        "review_encoding_flag": false,
         "expected_result": [
             ["","1---"],
             ["Ad-","lK--"],
@@ -703,6 +705,7 @@
         "case_name": "Add empty/barline sections when number of barlines are equal",
         "text_input": "Quanto eis {magis} plus predicabat {surdos fecit} audire et mutos loqui",
         "vol_input": "1---g--gk---h--h7---6------6---gf---g--gh--f--f---6------6---hk--hg--gh---gF---e--fG---g--g77---4---7k--k--j--k--h--g7---3",
+        "review_encoding_flag": true,
         "expected_result": [
             ["","1---"],
             ["Quan-","g----"],

--- a/volpiano_display_utilities/volpiano_syllabification.py
+++ b/volpiano_display_utilities/volpiano_syllabification.py
@@ -33,7 +33,7 @@ VOLPIANO_WORD_REGEX = re.compile(r".*?-{3,}|.+$")
 VOLPIANO_SYLLABLE_REGEX = re.compile(r".*?-{2,}|.+$")
 
 
-def prepare_volpiano_for_syllabification(raw_volpiano_str: str) -> str:
+def prepare_volpiano_for_syllabification(raw_volpiano_str: str) -> Tuple[str, bool]:
     """
     Prepare volpiano string for syllabification:
     - Remove any invalid characters
@@ -42,46 +42,83 @@ def prepare_volpiano_for_syllabification(raw_volpiano_str: str) -> str:
 
     raw_volpiano_str [str]: unprocessed volpiano string
 
-    returns [str]: preprocessed volpiano string without
-        beginning clef and invalid characters
+    returns [str, bool]: preprocessed volpiano string without
+        beginning clef and invalid characters and boolean indicating
+        whether invalid volpiano characters or character preceding
+        clef were removed
     """
     # Remove existing clef and any material preceding the
     # clef.
-    vol_clef_rmvd: str = STARTING_MATERIAL_REGEX.sub("", raw_volpiano_str)
-    processed_vol = INVALID_VOLPIANO_CHARS_REGEX.sub("", vol_clef_rmvd)
+    vol_chars_rmvd_flag = False
+    # Check whether the volpiano string clef was correctly encoded before
+    # removing it.
+    if raw_volpiano_str[0:4] != "1---" or raw_volpiano_str[0:5] == "1----":
+        vol_chars_rmvd_flag = True
+    vol_clef_rmvd = STARTING_MATERIAL_REGEX.sub("", raw_volpiano_str)
+    processed_vol, num_substitutions = INVALID_VOLPIANO_CHARS_REGEX.subn(
+        "", vol_clef_rmvd
+    )
+    # Check whether any invalid characters were removed from the volpiano
+    if num_substitutions > 0:
+        vol_chars_rmvd_flag = True
     logging.debug("Preprocessed volpiano string: %s", processed_vol)
-    return processed_vol
+    return processed_vol, vol_chars_rmvd_flag
 
 
-def syllabify_volpiano(volpiano: str) -> List[SyllabifiedVolpianoSection]:
+def syllabify_volpiano(volpiano: str) -> Tuple[List[SyllabifiedVolpianoSection], bool]:
     """
     Split the volpiano string into sections, words, and syllables.
 
     volpiano [str]: volpiano string
 
-    returns [List[SyllabifiedVolpianoSection]: An list of SyllabifiedVolpianoSection
-        objects containing the syllabified volpiano string.
+    returns [List[SyllabifiedVolpianoSection, bool]: A list of SyllabifiedVolpianoSection
+        objects containing the syllabified volpiano string and a boolean flagging whether
+        the volpiano was improperly spaced.
         See syllabified_section.py for more information.
     """
+    volpiano_improperly_spaced = False
     volpiano_sections: List[str] = VOLPIANO_SECTIONING_REGEX.split(volpiano)
     # Filter out empty sections created by the split
     volpiano_sections = list(filter(lambda x: x != "", volpiano_sections))
     syllabified_volpiano: List[SyllabifiedVolpianoSection] = []
-    for vol_sec in volpiano_sections:
-        # We don't syllabify barlines or missing music markers
+    for vol_sec_idx, vol_sec in enumerate(volpiano_sections):
+        # We don't syllabify barlines or missing music markers, but we
+        # do check whether they are encoded with the appropriate spacing.
         if vol_sec[0] in "346":
+            # Check if missing music sections are encoded as
+            # "6------6---", with any break markers (7's) entered
+            # immediate following the second "6".
+            if vol_sec[0] == "6" and (
+                vol_sec[-3:] != "---"
+                or vol_sec[1:8] != "------6"
+                or len(vol_sec.replace("7", "")) != 11
+            ):
+                volpiano_improperly_spaced = True
+            # Check if barlines are encoded as "3---" or "4---",
+            # with any break markers (7's) entered immediately
+            # following the "3" or "4".
+            elif (
+                vol_sec[0] in "34"
+                and vol_sec_idx != len(vol_sec) - 1
+                and (vol_sec[-3:] != "---" or len(vol_sec.replace("7", "")) != 4)
+            ):
+                volpiano_improperly_spaced = True
             syllabified_volpiano.append(SyllabifiedVolpianoSection([[vol_sec]]))
             continue
         vol_words = VOLPIANO_WORD_REGEX.findall(vol_sec)
         syllabified_words: List[List[str]] = []
         for vol_word in vol_words:
             vol_syls = VOLPIANO_SYLLABLE_REGEX.findall(vol_word)
+            # Check if the last syllable of the word is improperly spaced
+            # with three and only three trailing hyphens.
+            if vol_syls[-1][-3:] != "---" or vol_syls[-1][-4] == "-":
+                volpiano_improperly_spaced = True
             syllabified_words.append(vol_syls)
         syllabified_volpiano.append(SyllabifiedVolpianoSection(syllabified_words))
     logging.debug(
         "Syllabified volpiano: %s", ", ".join(str(s) for s in syllabified_volpiano)
     )
-    return syllabified_volpiano
+    return syllabified_volpiano, volpiano_improperly_spaced
 
 
 def ensure_end_of_word_spacing(volpiano: str) -> str:

--- a/volpiano_display_utilities/volpiano_syllabification.py
+++ b/volpiano_display_utilities/volpiano_syllabification.py
@@ -111,10 +111,11 @@ def syllabify_volpiano(volpiano: str) -> Tuple[List[SyllabifiedVolpianoSection],
             vol_syls = VOLPIANO_SYLLABLE_REGEX.findall(vol_word)
             # Check if the last syllable of the word is improperly spaced
             # with three and only three trailing hyphens.
-            final_syl_of_word = vol_syls[-1]
-            if final_syl_of_word[-3:] != "---" or len(final_syl_of_word) < 4:
-                volpiano_improperly_spaced = True
-            elif vol_syls[-1][-4] == "-":
+            try:
+                final_syl_of_word = vol_syls[-1]
+                if final_syl_of_word[-3:] != "---" or final_syl_of_word[-4] == "-":
+                    volpiano_improperly_spaced = True
+            except IndexError:
                 volpiano_improperly_spaced = True
             syllabified_words.append(vol_syls)
         syllabified_volpiano.append(SyllabifiedVolpianoSection(syllabified_words))

--- a/volpiano_display_utilities/volpiano_syllabification.py
+++ b/volpiano_display_utilities/volpiano_syllabification.py
@@ -111,7 +111,10 @@ def syllabify_volpiano(volpiano: str) -> Tuple[List[SyllabifiedVolpianoSection],
             vol_syls = VOLPIANO_SYLLABLE_REGEX.findall(vol_word)
             # Check if the last syllable of the word is improperly spaced
             # with three and only three trailing hyphens.
-            if vol_syls[-1][-3:] != "---" or vol_syls[-1][-4] == "-":
+            final_syl_of_word = vol_syls[-1]
+            if final_syl_of_word[-3:] != "---" or len(final_syl_of_word) < 4:
+                volpiano_improperly_spaced = True
+            elif vol_syls[-1][-4] == "-":
                 volpiano_improperly_spaced = True
             syllabified_words.append(vol_syls)
         syllabified_volpiano.append(SyllabifiedVolpianoSection(syllabified_words))


### PR DESCRIPTION
The `align_text_and_volpiano` function now returns an alignment *and* a boolean flag that indicates whether the volpiano and text are properly encoded. A return value of `True` is meant to indicate the need for manual correction of the encoding. This return value is now tested in volpiano syllabification and alignment tests. 

As an additional test, every chant on Cantus Database with a melody and a manuscript spelling full text encoded (n = 48,639) was aligned. Only 1 chant failed to align completely and a total of 18,220 chants aligned with manual correction suggested. The chant that failed was 254921, which seems now to be a bit of an edge case for which I don't think we have a convention (although maybe we make what @annamorphism has edited it to be the convention, see #38).

Fixes #35.