### PR TITLE
Change prefix logic to check for following vowel

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ flowchart TD
     A --> J
 ```
 
-*Note (1)*: Prefixes considered are "ab", "ob", "ad", "per", "sub", "in", and "con".
+*Note (1)*: Prefixes considered are "ab", "ob", "ad", "per", "sub", "in", "con" and "co". Prefixes are only removed when they are followed by a vowel; if not followed by a vowel, the rules regarding consonant placement are the same for the prefix as the rest of the word. An example will help illustrate. The word "perviam" should be syllabified "per-vi-am": the division of "rv" into two separate syllables follows the general rule of consonant placement (add the first consonant to the preceding syllable and the second consonant to the following syllable). The word "periurem", however, should be syllabified "per-iu-rem." Here, the general rule of consonant placement would call for the "r" to adhere to the following syllable. Because it is a prefix, however, the "r" stays in the first syllable.
 
 *Note (2)*: Written "i"s and "y"s may be semivowels and written "u"s may be semi-vowels or consonants. 
 "I"s are semivowels:

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ flowchart TD
     A --> J
 ```
 
-*Note (1)*: Prefixes considered are "ab", "ob", "ad", "per", "sub", "in", "con" and "co". Prefixes are only removed when they are followed by a vowel; if not followed by a vowel, the rules regarding consonant placement are the same for the prefix as the rest of the word. An example will help illustrate. The word "perviam" should be syllabified "per-vi-am": the division of "rv" into two separate syllables follows the general rule of consonant placement (add the first consonant to the preceding syllable and the second consonant to the following syllable). The word "periurem", however, should be syllabified "per-iu-rem." Here, the general rule of consonant placement would call for the "r" to adhere to the following syllable. Because it is a prefix, however, the "r" stays in the first syllable.
+*Note (1)*: Prefixes considered are "ab", "ob", "ad", "per", "sub", "in", "con", and "co". Prefixes are only removed when they are followed by a vowel; if not followed by a vowel, the rules regarding consonant placement are the same for the prefix as the rest of the word. An example will help illustrate. The word "perviam" should be syllabified "per-vi-am": the division of "rv" into two separate syllables follows the general rule of consonant placement (add the first consonant to the preceding syllable and the second consonant to the following syllable). The word "periurem", however, should be syllabified "per-iu-rem." Here, the general rule of consonant placement would call for the "r" to adhere to the following syllable. Because it is a prefix, however, the "r" stays in the first syllable.
 
 *Note (2)*: Written "i"s and "y"s may be semivowels and written "u"s may be semi-vowels or consonants. 
 "I"s are semivowels:

--- a/tests/word_syllabification_tests.csv
+++ b/tests/word_syllabification_tests.csv
@@ -91,3 +91,4 @@ compressans,com-pres-sans,
 principem,prin-ci-pem,
 redemptor,re-demp-tor, 
 imperator,im-pe-ra-tor
+coegerunt,co-e-ge-runt

--- a/volpiano_display_utilities/latin_word_syllabification.py
+++ b/volpiano_display_utilities/latin_word_syllabification.py
@@ -57,7 +57,7 @@ _NASALIZED_CONSONANTS: set = {"m", "n"}
 
 # Prefix groups are groups of characters that serve as common prefixes. For details,
 # see README.
-_PREFIX_GROUPS: set = {"ab", "ob", "ad", "per", "sub", "in", "con"}
+_PREFIX_GROUPS: set = {"ab", "ob", "ad", "per", "sub", "in", "con", "co"}
 
 _VOWELS: set = {"a", "e", "i", "o", "u", "y"}
 _VOWELS_AEOU: set = {"a", "e", "o", "u"}
@@ -96,7 +96,8 @@ def split_word_by_syl_bounds(word: str, syl_bounds: List[int]) -> List[str]:
 
 def _get_prefixes(word: str) -> str:
     """
-    Returns the prefix of a word, if it has one.
+    Returns the prefix of a word, if it has one that is followed by a vowel.
+    FOr details on prefixes, see README.
 
     word [str]: word to check for prefix
 
@@ -107,7 +108,9 @@ def _get_prefixes(word: str) -> str:
         # If the word is itself one of the prefixes (eg. "in" can
         # be a word or a prefix), doen't return a prefix
         if word.startswith(prefix) and (word != prefix):
-            return prefix
+            prefix_length = len(prefix)
+            if word[prefix_length] in _VOWELS:
+                return prefix
     return ""
 
 

--- a/volpiano_display_utilities/latin_word_syllabification.py
+++ b/volpiano_display_utilities/latin_word_syllabification.py
@@ -97,7 +97,7 @@ def split_word_by_syl_bounds(word: str, syl_bounds: List[int]) -> List[str]:
 def _get_prefixes(word: str) -> str:
     """
     Returns the prefix of a word, if it has one that is followed by a vowel.
-    FOr details on prefixes, see README.
+    For details on prefixes, see README.
 
     word [str]: word to check for prefix
 
@@ -106,7 +106,7 @@ def _get_prefixes(word: str) -> str:
     """
     for prefix in _PREFIX_GROUPS:
         # If the word is itself one of the prefixes (eg. "in" can
-        # be a word or a prefix), doen't return a prefix
+        # be a word or a prefix), don't return a prefix
         if word.startswith(prefix) and (word != prefix):
             prefix_length = len(prefix)
             if word[prefix_length] in _VOWELS:


### PR DESCRIPTION
This PR: 

- Adds `co` to the list of prefixes
- Adds a test word `coegerunt` (`co-e-ge-runt`) that has this prefix
- Changes the prefix logic so that a prefix only requires special handling if it is followed by a vowel. The reasons for this are outlined in the changes this PR introduces to the README. In short, if the prefix is not followed by a vowel, then the usual consonant-placement rules apply and no special handling is required. 

Closes #46.