### PR TITLE
Handle issues when improper characters are passed to latin word syllabifier

### DIFF
--- a/.github/workflows/test_module.yml
+++ b/.github/workflows/test_module.yml
@@ -7,7 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install poetry
+        run: pipx install poetry
       - uses: actions/setup-python@v4
         with:
           python-version: 3.8
-      - run: python -m unittest tests.tests
+      - run: poetry install
+      - run: poetry run python -m unittest tests.tests

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The `align_text_and_volpiano` function also takes the following optional argumen
 
 ### Word Syllabification
 
-`syllabify_word` syllabifies individual latin words according to linguistic rules. `syllabify_word` can either return a list of syllable boundaries or a string hyphenated at syllable boundaries. Strings passed to `syllabify_word` must contain only ASCII alphabetic characters; strings with other characters will raise a `ValueError`. 
+`syllabify_word` syllabifies individual latin words according to linguistic rules. `syllabify_word` can either return a list of syllable boundaries or a string hyphenated at syllable boundaries. Strings passed to `syllabify_word` must contain only ASCII alphabetic characters; strings with other characters will raise a `LatinError`. 
 
 ```python 
 >>> from latin_word_syllabification import syllabify_word

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,6 +1,7 @@
 """
 Tests functioanlity of this package.
 """
+
 import unittest
 import json
 import csv
@@ -8,6 +9,7 @@ import csv
 from volpiano_display_utilities.latin_word_syllabification import (
     syllabify_word,
     split_word_by_syl_bounds,
+    LatinError,
 )
 from volpiano_display_utilities.cantus_text_syllabification import (
     _clean_text,
@@ -64,6 +66,18 @@ class TestWordSyllabification(unittest.TestCase):
                 self.assertEqual(
                     "".join(split_word_by_syl_bounds(word, word_syl_bounds[word])),
                     expected,
+                )
+
+    def test_character_check(self):
+        """
+        Tests that an error is raised with invalid characters.
+        """
+        invalid_characters = "1%[}|~`"
+        some_valid_characters = "allelu"
+        for char in invalid_characters:
+            with self.subTest(char=char):
+                self.assertRaises(
+                    LatinError, syllabify_word, f"{some_valid_characters}{char}"
                 )
 
 
@@ -270,6 +284,17 @@ class TestCantusTextSyllabification(unittest.TestCase):
                 syllabified_text_list,
                 expected_result,
             )
+        with self.subTest("Improperly encoded #"):
+            preceding_hash_text = "rorate #-li de super"
+            following_hash_text = "rorate cae-# de super"
+            with self.assertRaises(LatinError):
+                syllabify_text(preceding_hash_text)
+            with self.assertRaises(LatinError):
+                syllabify_text(following_hash_text)
+        with self.subTest("Improperly encoded [ & ]"):
+            test_with_bad_bracket = "rorate | caeli [de super]"
+            with self.assertRaises(LatinError):
+                syllabify_text(test_with_bad_bracket)
 
 
 class TestVolpianoSyllabification(unittest.TestCase):

--- a/volpiano_display_utilities/latin_word_syllabification.py
+++ b/volpiano_display_utilities/latin_word_syllabification.py
@@ -71,6 +71,12 @@ _QG = {"q", "g"}
 LATIN_ALPH_REGEX = re.compile(r"[^a-zA-Z]")
 
 
+class LatinError(ValueError):
+    """
+    Raised when a non-alphabetic character is found in a Latin word.
+    """
+
+
 def split_word_by_syl_bounds(word: str, syl_bounds: List[int]) -> List[str]:
     """
     Splits a word into syllables based on syllable boundaries.
@@ -379,7 +385,7 @@ def syllabify_word(word: str, return_string: bool = False) -> Union[List[int], s
     if not isinstance(word, str):
         raise TypeError(f"Word must be a string. Got {type(word)}.")
     if LATIN_ALPH_REGEX.search(word):
-        raise ValueError(f"Word {word} contains non-alphabetic characters.")
+        raise LatinError(f"Word {word} contains non-alphabetic characters.")
     lowercase_word = word.lower()
     syllable_boundaries = _syllabify(lowercase_word)
     if return_string:

--- a/volpiano_display_utilities/text_volpiano_alignment.py
+++ b/volpiano_display_utilities/text_volpiano_alignment.py
@@ -6,6 +6,7 @@ at https://cantusdatabase.org/documents). See the README for more information.
 
 Use align_text_and_volpiano to align the text and melody strings of a chant.
 """
+
 import logging
 from itertools import zip_longest
 from typing import List, Tuple, TypeVar
@@ -334,11 +335,13 @@ def align_text_and_volpiano(
     review_encoding_flag: bool = False
     # If cleaning of text is required, we set the review_encoding_flag to True
     try:
-        syllabified_text = syllabify_text(
+        syllabified_text, spacing_adjusted = syllabify_text(
             chant_text, clean_text=False, text_presyllabified=text_presyllabified
         )
+        if spacing_adjusted:
+            review_encoding_flag = True
     except ValueError:
-        syllabified_text = syllabify_text(
+        syllabified_text, spacing_adjusted = syllabify_text(
             chant_text, clean_text=True, text_presyllabified=text_presyllabified
         )
         review_encoding_flag = True


### PR DESCRIPTION
This PR:

- Introduces `LatinError`, and exception that inherits from `ValueError`, to specifically identify errors where a latin word passed to the syllabification script has improper characters. This is intended to allow applications using this utility to handle these exceptions as appropriate.
- Introduces some logic in `cantus_text_syllabification.syllabify_text` that adds spacing to improperly space instances of hash (`#`)
- Cleans up a number of typing issues.

Closes #48 and closes #49 for the purposes of this repository. 

Opened https://github.com/DDMAL/CantusDB/issues/1423 for CantusDB to handle `LatinError`