### PR TITLE
Feat: Add handling of half-bar construct

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "volpiano_display_utilities"
-version = "1.1.4"
+version = "1.2.0"
 description = "Provides a set of tools for the syllabification of latin chant texts and the alignment of chant texts with Volpiano-encoded melodies according to the conventionss of the Cantus Database."
 authors = ["Your Name <you@example.com>"]
 license = "MIT"

--- a/tests/alignment_test_cases.json
+++ b/tests/alignment_test_cases.json
@@ -150,17 +150,16 @@
             ["", "4"]
         ]
     },
-    {
-        "case_name": "Test alignment: Missing music encoded with too few internal hyphens",
-        "text_input": "in {diebus} e- {ius} obsessa est",
-        "vol_input": "1---f---6--6---f---6----6---g--hg-hgf--ef-gef---ed---3",
-        "review_encoding_flag": true,
+        {
+        "case_name": "Test alignment: Half-bar encoded",
+        "text_input": "in eius obsessa est",
+        "vol_input": "1---f---6---f--ga---6---g--hg-hgf--ef-gef---ed---3",
+        "review_encoding_flag": false,
         "expected_result": [
             ["", "1---"],
-            ["in", "f---"],
-            ["{diebus}", "6------6---"],
-            ["e-", "f---"],
-            ["{ius}", "6------6---"],
+            ["in", "f---6---"],
+            ["e-", "f--"],
+            ["ius", "ga---6---"],
             ["ob-", "g--"],
             ["ses-", "hg-hgf--"],
             ["sa", "ef-gef---"],
@@ -169,19 +168,18 @@
         ]
     },
     {
-        "case_name": "Test alignment: Missing music encoded with too many internal hyphens",
-        "text_input": "in {diebus} e- {ius} obsessa est",
-        "vol_input": "1---f---6-------6---f---6-----------6---g--hg-hgf--ef-gef---ed---3",
-        "review_encoding_flag": true,
+        "case_name": "Test alignment: Half-bar encoded with breaks",
+        "text_input": "in eius obsessa est",
+        "vol_input": "1---f---67---f--ga---677---g--hg-hgf--ef-gef---6777---ed---3",
+        "review_encoding_flag": false,
         "expected_result": [
             ["", "1---"],
-            ["in", "f---"],
-            ["{diebus}", "6------6---"],
-            ["e-", "f---"],
-            ["{ius}", "6------6---"],
+            ["in", "f---67---"],
+            ["e-", "f--"],
+            ["ius", "ga---677---"],
             ["ob-", "g--"],
             ["ses-", "hg-hgf--"],
-            ["sa", "ef-gef---"],
+            ["sa", "ef-gef---6777---"],
             ["est", "ed---"],
             ["", "3"]
         ]

--- a/volpiano_display_utilities/syllabified_section.py
+++ b/volpiano_display_utilities/syllabified_section.py
@@ -15,7 +15,7 @@ class SyllabifiedSection:
     def __init__(self, section: List[List[str]]):
         self.section = section
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.section)
 
     def __repr__(self) -> str:

--- a/volpiano_display_utilities/volpiano_syllabification.py
+++ b/volpiano_display_utilities/volpiano_syllabification.py
@@ -24,13 +24,17 @@ STARTING_MATERIAL_REGEX = re.compile(r"^.*?1-*")
 # Split sections of volpiano on clefs, barline markers, and missing
 # music indicators. Includes spacing (hyphens) and section markers (7's)
 # in the split, if present.
-VOLPIANO_SECTIONING_REGEX = re.compile(r"([34][\-7]*|6[\-7]*6[\-7]*)")
+VOLPIANO_SECTIONING_REGEX = re.compile(r"([34][\-7]*|6-{6}6[\-7]*)")
 
 # Split words on sequences of three hyphens or at the end of the string.
-VOLPIANO_WORD_REGEX = re.compile(r".*?-{3,}|.+$")
+# Exception: For a 6 that is not encoding a missing music section (ie. for
+# one that just encodes a half-bar), include it at the end of the previous word.
+VOLPIANO_WORD_REGEX = re.compile(r".*?-{3,}(?:67{0,3}---)?|.+$")
 
 # Split syllables on sequences of two hyphens or at the end of the string.
-VOLPIANO_SYLLABLE_REGEX = re.compile(r".*?-{2,}|.+$")
+# Exception: If a half-bar construct follows a syllable (e.g. "f---6---g")
+# don't split the syllable from the following half-bar
+VOLPIANO_SYLLABLE_REGEX = re.compile(r".*?-{2,}(?:67{0,3}---)?|.+$")
 
 
 def prepare_volpiano_for_syllabification(raw_volpiano_str: str) -> Tuple[str, bool]:


### PR DESCRIPTION
Modify volpiano syllabification and sectioning to require missing music sections to be encoded with exactly 6 internal hyphens.

All other 6's are now treated as half-bars, and are appended to the end of the previous volpiano syllable for alignment along with any immediately following break marks ("7", "77", or "777").

Updates `pyproject.toml` to create a new release.

Closes #57.